### PR TITLE
fix: 🐛 error when no resource is set, add test

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -120,7 +120,7 @@ export default class Model extends StaticModel {
       throw new Error('The for() method takes a minimum of one argument.')
     }
 
-    if (args[0] === null && this._fromResource) {
+    if (args[0] === null) {
       this._from(null)
       return
     }

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -925,6 +925,19 @@ describe('Model methods', () => {
     await post.save()
   })
 
+  test('for() method reset works without resource', async () => {
+    axiosMock.onPost().reply((config) => {
+      expect(config.method).toEqual('post')
+      expect(config.url).toEqual('http://localhost/posts')
+
+      return [200, {}]
+    })
+
+    const post = new Post({ text: 'Hello' })
+    post.for(null)
+    await post.save()
+  })
+
   test('Calling for() with multiple arguments produces the correct URL', () => {
     const user = new User({ id: 1 })
     const post = new Post({ id: 2 })


### PR DESCRIPTION
## Checklist

- [x] Tests
- [x] Type definitions 
